### PR TITLE
feat: Implement range circle functionality in MapPopup and mapStore

### DIFF
--- a/Taipei-City-Dashboard-FE/src/components/map/MapPopup.vue
+++ b/Taipei-City-Dashboard-FE/src/components/map/MapPopup.vue
@@ -1,10 +1,15 @@
 <!-- Developed by Taipei Urban Intelligence Center 2023-2024-->
 
 <!-- This component is mounted programmically by the mapstore. "mapConfig" and "popupContent" are passed in in the mapStore -->
-<script setup></script>
+<script setup>
+import { useMapStore } from '../../store/mapStore'
+
+const mapStore = useMapStore()
+</script>
 
 <template>
   <div class="mappopup">
+    
     <div class="mappopup-tab">
       <div
         v-for="(mapConfig, index) in mapConfigs"
@@ -26,6 +31,22 @@
                 : mapConfig.title
           }}
         </button>
+		    <!-- Range Buttons -->
+			<div 
+				class="mappopup-range-buttons"
+				@mouseleave="handleRangeLeave"
+				>
+				<button
+					v-for="(radius, index) in [500, 2000, 5000]"
+					:key="radius"
+					:class="['range-button', `range-button-${index}`]"
+					@mouseenter="handleRangeHover(radius)"
+					@touchstart.prevent="handleRangeHover(radius)"
+					@touchend.prevent="handleRangeLeave"
+				>
+					{{ `${radius / 1000}km` }}
+				</button>
+			</div>
       </div>
     </div>
     <div class="mappopup-content">
@@ -96,26 +117,31 @@
 	box-shadow: 0px 0px 10px rgb(35, 35, 35) !important;
 	border-radius: 5px !important;
 	background-color: var(--color-component-background) !important;
+	transition: opacity 0.3s ease !important;
 }
 
 .mapboxgl-popup-anchor-bottom .mapboxgl-popup-tip,
 .mapboxgl-popup-anchor-bottom-left .mapboxgl-popup-tip,
 .mapboxgl-popup-anchor-bottom-right .mapboxgl-popup-tip {
 	border-top-color: var(--color-border) !important;
+	transition: opacity 0.3s ease !important;
 }
 
 .mapboxgl-popup-anchor-top .mapboxgl-popup-tip,
 .mapboxgl-popup-anchor-top-left .mapboxgl-popup-tip,
 .mapboxgl-popup-anchor-top-right .mapboxgl-popup-tip {
 	border-bottom-color: var(--color-border) !important;
+	transition: opacity 0.3s ease !important;
 }
 
 .mapboxgl-popup-anchor-left .mapboxgl-popup-tip {
 	border-right-color: var(--color-border) !important;
+	transition: opacity 0.3s ease !important;
 }
 
 .mapboxgl-popup-anchor-right .mapboxgl-popup-tip {
 	border-left-color: var(--color-border) !important;
+	transition: opacity 0.3s ease !important;
 }
 
 .mapboxgl-popup-close-button {
@@ -136,9 +162,78 @@
 		color: var(--color-complement-text);
 	}
 
+	.mappopup-tab-active {
+		display: flex;
+	}
+
+	&-range-buttons {
+		margin-left: 12px;
+		display: flex;
+		gap: 2px;
+		justify-content: center;
+
+		.range-button {
+			padding: 6px 12px;
+			border-radius: 15px;
+			background-color: var(--color-highlight);
+			color: white;
+			font-size: var(--font-s);
+			font-weight: 500;
+			border: none;
+			cursor: auto;
+			transition: all 0.2s ease;
+			user-select: none;
+			position: relative;
+			
+			&:hover {
+				transform: translateY(-1px);
+				box-shadow: 0 4px 8px rgba(0, 124, 191, 0.3);
+				z-index: 10;
+			}
+
+			&:active {
+				opacity: 0.6;
+				transform: translateY(0);
+			}
+
+			margin-bottom: 0;
+
+			// 500m button
+			&.range-button-0 {
+				background-color: #5A9BF8;
+				
+				&:hover {
+					background-color: #4A8AE7;
+					box-shadow: 0 4px 8px rgba(90, 155, 248, 0.3);
+				}
+			}
+
+			// 2km button  
+			&.range-button-1 {
+				background-color: #287DF6;
+				
+				&:hover {
+					background-color: #1A6CE5;
+					box-shadow: 0 4px 8px rgba(40, 125, 246, 0.3);
+				}
+			}
+
+			// 5km button
+			&.range-button-2 {
+				background-color: #0960DC;
+				
+				&:hover {
+					background-color: #084FCB;
+					box-shadow: 0 4px 8px rgba(9, 96, 220, 0.3);
+				}
+			}
+		}
+	}
+
 	&-tab {
 		display: flex;
 		margin-bottom: 0.5rem;
+		transition: opacity 0.3s ease;
 
 		button {
 			margin: 0 4px 0 0;
@@ -166,6 +261,7 @@
 
 	&-content {
 		width: 100%;
+		transition: opacity 0.3s ease;
 
 		div {
 			display: flex;

--- a/Taipei-City-Dashboard-FE/src/store/mapStore.js
+++ b/Taipei-City-Dashboard-FE/src/store/mapStore.js
@@ -15,6 +15,7 @@ import { ArcLayer } from "@deck.gl/layers";
 import { MapboxOverlay } from "@deck.gl/mapbox";
 import axios from "axios";
 import http from "../router/axios.js";
+import * as turf from "@turf/turf";
 
 // Other Stores
 import { useAuthStore } from "./authStore";
@@ -71,6 +72,9 @@ export const useMapStore = defineStore("map", {
 		userLocation: { latitude: null, longitude: null },
 		// Store icon mapping
 		iconMapping: {},
+		// Store range circle state
+		rangeCircleVisible: false,
+		rangeCircleLayer: null,
 	}),
 	actions: {
 		/* Initialize Mapbox */
@@ -992,14 +996,110 @@ export const useMapStore = defineStore("map", {
 				.setHTML('<div id="vue-popup-content"></div>')
 				.addTo(this.map);
 			// Mount a vue component (MapPopup) to the id "vue-popup-content" and pass in data
+			const currentMapStore = this; // Capture the current mapStore instance
 			const PopupComponent = defineComponent({
 				extends: MapPopup,
 				setup() {
+					let hoverTimeout = null;
+					let leaveTimeout = null;
+					let isRangeActive = false;
+					let currentRadius = null;
+
+					// Get popup coordinates for range circles
+					const getPopupCoordinates = () => {
+						const coordinates = currentMapStore.popup?.getLngLat();
+						return coordinates;
+					}
+
+					// Handle range button hover
+					const handleRangeHover = (radius) => {
+						// Clear any pending leave timeout
+						if (leaveTimeout) {
+							clearTimeout(leaveTimeout);
+							leaveTimeout = null;
+						}
+
+						// If same radius is already active, don't retrigger
+						if (isRangeActive && currentRadius === radius) {
+							return;
+						}
+
+						// Clear any pending hover timeout
+						if (hoverTimeout) {
+							clearTimeout(hoverTimeout);
+							hoverTimeout = null;
+						}
+
+						// If switching between ranges, update immediately
+						if (isRangeActive && currentRadius !== radius) {
+							const coordinates = getPopupCoordinates();
+							if (coordinates) {
+								currentRadius = radius;
+								currentMapStore.showRangeCircle(coordinates, radius);
+								return;
+							}
+						}
+
+						// Add small delay for initial trigger
+						hoverTimeout = setTimeout(() => {
+							const coordinates = getPopupCoordinates();
+							if (coordinates) {
+								isRangeActive = true;
+								currentRadius = radius;
+								currentMapStore.showRangeCircle(coordinates, radius);
+								// Make popup very faint
+								if (currentMapStore.popup) {
+									const popupElement = currentMapStore.popup.getElement();
+									const contentEl = popupElement.querySelector('.mapboxgl-popup-content');
+									const tipEl = popupElement.querySelector('.mapboxgl-popup-tip');
+									if (contentEl) {
+										contentEl.style.opacity = '0.1';
+									}
+									if (tipEl) {
+										tipEl.style.opacity = '0.1';
+									}
+								}
+							}
+						}, 50);
+					}
+
+					// Handle range button leave
+					const handleRangeLeave = () => {
+						// Clear any pending hover timeout
+						if (hoverTimeout) {
+							clearTimeout(hoverTimeout);
+							hoverTimeout = null;
+						}
+
+						// Add delay to prevent rapid switching
+						leaveTimeout = setTimeout(() => {
+							if (isRangeActive) {
+								isRangeActive = false;
+								currentRadius = null;
+								currentMapStore.hideRangeCircle();
+								// Restore popup opacity
+								if (currentMapStore.popup) {
+									const popupElement = currentMapStore.popup.getElement();
+									const contentEl = popupElement.querySelector('.mapboxgl-popup-content');
+									const tipEl = popupElement.querySelector('.mapboxgl-popup-tip');
+									if (contentEl) {
+										contentEl.style.opacity = '1';
+									}
+									if (tipEl) {
+										tipEl.style.opacity = '1';
+									}
+								}
+							}
+						}, 100);
+					}
+
 					// Only show the data of the topmost layer
 					return {
 						popupContent: parsedPopupContent,
 						mapConfigs: mapConfigs,
 						activeTab: ref(0),
+						handleRangeHover,
+						handleRangeLeave,
 					};
 				},
 			});
@@ -1015,6 +1115,8 @@ export const useMapStore = defineStore("map", {
 				this.popup.remove();
 			}
 			this.popup = null;
+			// Also remove any range circle when popup is removed
+			this.hideRangeCircle();
 		},
 		// 3. programmatically trigger the popup, instead of user click
 		manualTriggerPopup() {
@@ -1469,6 +1571,120 @@ export const useMapStore = defineStore("map", {
 			this.currentVisibleLayers = [];
 			this.removePopup();
 			this.tempMarkerCoordinates = null;
+		},
+
+		/* Range Circle Functions */
+		// Show range circle around the popup location
+		showRangeCircle(coordinates, radiusInMeters) {
+			if (!this.map || !coordinates) return;
+
+			// Remove existing range circle first
+			this.removeRangeCircle();
+
+			// Set range circle as visible
+			this.rangeCircleVisible = true;
+
+			// Get color based on radius
+			let circleColor = '#007cbf'; // default
+			switch (radiusInMeters) {
+				case 500:
+					circleColor = '#5A9BF8';
+					break;
+				case 2000:
+					circleColor = '#287DF6';
+					break;
+				case 5000:
+					circleColor = '#0960DC';
+					break;
+			}
+
+			try {
+				// Create circle using Turf.js with meters directly
+				const center = [coordinates.lng, coordinates.lat];
+				
+				const circle = turf.circle(center, radiusInMeters, {
+					steps: 64,
+					units: 'meters'
+				});
+
+				// Add source and layer for the circle
+				const sourceId = 'range-circle-source';
+				const layerId = 'range-circle-layer';
+				const outlineLayerId = 'range-circle-outline';
+
+				this.map.addSource(sourceId, {
+					type: 'geojson',
+					data: circle
+				});
+
+				this.map.addLayer({
+					id: layerId,
+					type: 'fill',
+					source: sourceId,
+					layout: {},
+					paint: {
+						'fill-color': circleColor,
+						'fill-opacity': 0.15
+					}
+				});
+
+				this.map.addLayer({
+					id: outlineLayerId,
+					type: 'line',
+					source: sourceId,
+					layout: {},
+					paint: {
+						'line-color': circleColor,
+						'line-width': 2,
+						'line-opacity': 0.8
+					}
+				});
+
+				this.rangeCircleLayer = layerId;
+			} catch (error) {
+				console.error('Error creating range circle:', error);
+			}
+		},
+
+		// Remove range circle layers
+		removeRangeCircle() {
+			if (!this.map) return;
+
+			const sourceId = 'range-circle-source';
+			const layerId = 'range-circle-layer';
+			const outlineLayerId = 'range-circle-outline';
+
+			if (this.map.getLayer(outlineLayerId)) {
+				this.map.removeLayer(outlineLayerId);
+			}
+			if (this.map.getLayer(layerId)) {
+				this.map.removeLayer(layerId);
+			}
+			if (this.map.getSource(sourceId)) {
+				this.map.removeSource(sourceId);
+			}
+
+			this.rangeCircleLayer = null;
+		},
+
+		// Hide range circle and restore popup
+		hideRangeCircle() {
+			this.rangeCircleVisible = false;
+			this.removeRangeCircle();
+		},
+
+		// Hide popup (used when showing range circle)
+		hidePopup() {
+			if (this.popup) {
+				this.popup.getElement().style.display = 'none';
+			}
+		},
+
+		// Show popup (used when hiding range circle)
+		showPopup() {
+			if (this.popup) {
+				this.popup.getElement().style.display = 'block';
+			}
 		},
 	},
 });


### PR DESCRIPTION
- Added range buttons to MapPopup.vue for selecting distance ranges (500m, 2km, 5km).
- Integrated range circle display logic in mapStore.js using Turf.js for accurate circle rendering.
- Enhanced popup behavior to adjust opacity when range circles are active.
- Introduced methods to show and hide range circles, improving user interaction with the map.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Summary

**Issue:** Enter the issue(s) this pull request resolves.

A clear and concise description of this pull request

## Type (Fill in "x" to check)

- [ ] Bug Fix
- [ ] New Feature

## Checklist

Please make sure that all items are checked before submitting this request.

- [ ] Code linter has been run and issues have all been resolved
- [ ] The code has been thoroughly tested and no visible bugs have been introduced
- [ ] The pull request will completely resolve the issue(s) mentioned
- [ ] The pull request only resolves the issue(s) mentioned and nothing more

## Additional context

Add any other context here.
